### PR TITLE
[1.15] Bump sbf-tools version

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -102,7 +102,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install Rust-BPF
-version=v1.32
+version=v1.33
 if [[ ! -e bpf-tools-$version.md || ! -e bpf-tools ]]; then
   (
     set -e

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -18,6 +18,13 @@ case "${unameOut}" in
     criterion_suffix=
     machine=linux
 esac
+unameOut="$(uname -m)"
+case "${unameOut}" in
+  arm64*)
+    arch=aarch64;;
+  *)
+    arch=x86_64
+esac
 
 download() {
   declare url="$1/$2/$3"
@@ -102,7 +109,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install Rust-BPF
-version=v1.33
+version=v1.34
 if [[ ! -e bpf-tools-$version.md || ! -e bpf-tools ]]; then
   (
     set -e
@@ -111,7 +118,7 @@ if [[ ! -e bpf-tools-$version.md || ! -e bpf-tools ]]; then
     job="download \
            https://github.com/solana-labs/bpf-tools/releases/download \
            $version \
-           solana-bpf-tools-$machine.tar.bz2 \
+           solana-bpf-tools-${machine}-${arch}.tar.bz2 \
            bpf-tools"
     get $version bpf-tools "$job"
   )

--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -606,22 +606,27 @@ fn build_sbf_package(config: &Config, target_directory: &Path, package: &cargo_m
     if legacy_program_feature_present {
         info!("Legacy program feature detected");
     }
+    let arch = if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "x86_64"
+    };
     let sbf_tools_download_file_name = if cfg!(target_os = "windows") {
         if config.arch == "bpf" {
-            "solana-bpf-tools-windows.tar.bz2"
+            format!("solana-bpf-tools-windows-{arch}.tar.bz2")
         } else {
-            "solana-sbf-tools-windows.tar.bz2"
+            format!("solana-sbf-tools-windows-{arch}.tar.bz2")
         }
     } else if cfg!(target_os = "macos") {
         if config.arch == "bpf" {
-            "solana-bpf-tools-osx.tar.bz2"
+            format!("solana-bpf-tools-osx-{arch}.tar.bz2")
         } else {
-            "solana-sbf-tools-osx.tar.bz2"
+            format!("solana-sbf-tools-osx-{arch}.tar.bz2")
         }
     } else if config.arch == "bpf" {
-        "solana-bpf-tools-linux.tar.bz2"
+        format!("solana-bpf-tools-linux-{arch}.tar.bz2")
     } else {
-        "solana-sbf-tools-linux.tar.bz2"
+        format!("solana-sbf-tools-linux-{arch}.tar.bz2")
     };
     let package = if config.arch == "bpf" {
         "bpf-tools"
@@ -633,7 +638,7 @@ fn build_sbf_package(config: &Config, target_directory: &Path, package: &cargo_m
         config,
         package,
         "https://github.com/solana-labs/sbf-tools/releases/download",
-        sbf_tools_download_file_name,
+        sbf_tools_download_file_name.as_str(),
         &target_path,
     )
     .unwrap_or_else(|err| {
@@ -936,7 +941,7 @@ fn main() {
 
     // The following line is scanned by CI configuration script to
     // separate cargo caches according to the version of sbf-tools.
-    let sbf_tools_version = String::from("v1.33");
+    let sbf_tools_version = String::from("v1.34");
     let version = format!("{}\nsbf-tools {}", crate_version!(), sbf_tools_version);
     let matches = clap::Command::new(crate_name!())
         .about(crate_description!())

--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -936,7 +936,7 @@ fn main() {
 
     // The following line is scanned by CI configuration script to
     // separate cargo caches according to the version of sbf-tools.
-    let sbf_tools_version = String::from("v1.32");
+    let sbf_tools_version = String::from("v1.33");
     let version = format!("{}\nsbf-tools {}", crate_version!(), sbf_tools_version);
     let matches = clap::Command::new(crate_name!())
         .about(crate_description!())

--- a/sdk/cargo-build-sbf/tests/crates.rs
+++ b/sdk/cargo-build-sbf/tests/crates.rs
@@ -105,6 +105,7 @@ fn test_generate_child_script_on_failure() {
 
 #[test]
 #[serial]
+#[ignore]
 fn test_sbfv2() {
     run_cargo_build("noop", &["--arch", "sbfv2"], false);
     let cwd = env::current_dir().expect("Unable to get current working directory");

--- a/sdk/sbf/scripts/install.sh
+++ b/sdk/sbf/scripts/install.sh
@@ -102,7 +102,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install Rust-SBF
-version=v1.32
+version=v1.33
 if [[ ! -e sbf-tools-$version.md || ! -e sbf-tools ]]; then
   (
     set -e

--- a/sdk/sbf/scripts/install.sh
+++ b/sdk/sbf/scripts/install.sh
@@ -18,6 +18,13 @@ case "${unameOut}" in
     criterion_suffix=
     machine=linux
 esac
+unameOut="$(uname -m)"
+case "${unameOut}" in
+  arm64*)
+    arch=aarch64;;
+  *)
+    arch=x86_64
+esac
 
 download() {
   declare url="$1/$2/$3"
@@ -102,7 +109,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install Rust-SBF
-version=v1.33
+version=v1.34
 if [[ ! -e sbf-tools-$version.md || ! -e sbf-tools ]]; then
   (
     set -e
@@ -110,7 +117,7 @@ if [[ ! -e sbf-tools-$version.md || ! -e sbf-tools ]]; then
     job="download \
            https://github.com/solana-labs/sbf-tools/releases/download \
            $version \
-           solana-sbf-tools-$machine.tar.bz2 \
+           solana-sbf-tools-${machine}-${arch}.tar.bz2 \
            sbf-tools"
     get $version sbf-tools "$job"
   )


### PR DESCRIPTION
Backport of:

* solana-labs/solana#30186
* solana-labs/solana#30397

We need them, because Solana v1.15 uses the old version of sbf-tools/platform-tools, which doesn't have the macos-arm64 tarball:

https://github.com/solana-labs/platform-tools/releases/tag/v1.32

They started to be included from v1.34, which is the version that this PR is bumping to:

https://github.com/solana-labs/platform-tools/releases/tag/v1.34